### PR TITLE
fixed-X knockoffs variables when the intercept exists

### DIFF
--- a/R/knockoff/R/knockoff_filter.R
+++ b/R/knockoff/R/knockoff_filter.R
@@ -92,11 +92,11 @@ NULL
 #' 
 #' @export
 knockoff.filter <- function(X, y,
-                              knockoffs=create.second_order,
-                              statistic=stat.glmnet_coefdiff, 
-                              fdr=0.10,
-                              offset=1
-                              ) {
+                            knockoffs=create.second_order,
+                            statistic=stat.glmnet_coefdiff, 
+                            fdr=0.10,
+                            offset=1
+                            ) {
   
   # Validate input types.
   if (is.data.frame(X)) {

--- a/R/knockoff/R/knockoff_filter.R
+++ b/R/knockoff/R/knockoff_filter.R
@@ -92,11 +92,11 @@ NULL
 #' 
 #' @export
 knockoff.filter <- function(X, y,
-                            knockoffs=create.second_order,
-                            statistic=stat.glmnet_coefdiff, 
-                            fdr=0.10,
-                            offset=1
-                            ) {
+                              knockoffs=create.second_order,
+                              statistic=stat.glmnet_coefdiff, 
+                              fdr=0.10,
+                              offset=1
+                              ) {
   
   # Validate input types.
   if (is.data.frame(X)) {

--- a/R/knockoff/man/create.fixed.Rd
+++ b/R/knockoff/man/create.fixed.Rd
@@ -6,6 +6,7 @@
 \usage{
 create.fixed(
   X,
+  intercept = F,
   method = c("sdp", "equi"),
   sigma = NULL,
   y = NULL,
@@ -15,6 +16,9 @@ create.fixed(
 \arguments{
 \item{X}{normalized n-by-p matrix of original variables.(\eqn{n \geq p}).}
 
+\item{intercept}{Will the intercept be fitted (TRUE) or set to zero
+(default=FALSE).}
+
 \item{method}{either "equi" or "sdp" (default: "sdp").
 This determines the method that will be used to minimize the correlation between the original variables and the knockoffs.}
 
@@ -22,7 +26,8 @@ This determines the method that will be used to minimize the correlation between
 
 \item{y}{vector of length n, containing the observed responses. 
 This is needed to estimate the noise level if the parameter \code{sigma} is not provided, 
-in case \eqn{p \leq n < 2p} (default: NULL).}
+in case \eqn{p \leq n < 2p}.
+When \code{intercept=TRUE}, it is needed to estimate the intercept in case \eqn{p \leq n < 2p+1} (default: NULL).}
 
 \item{randomize}{whether the knockoffs are constructed deterministically or randomized (default: F).}
 }
@@ -64,7 +69,6 @@ print(result$selected)
 Barber and Candes,
   Controlling the false discovery rate via knockoffs. 
   Ann. Statist. 43 (2015), no. 5, 2055--2085.
-  \doi{10.1214/15-AOS1337}
 }
 \seealso{
 Other create: 

--- a/R/knockoff/man/create_equicorrelated.Rd
+++ b/R/knockoff/man/create_equicorrelated.Rd
@@ -4,7 +4,7 @@
 \alias{create_equicorrelated}
 \title{Create equicorrelated fixed-X knockoffs.}
 \usage{
-create_equicorrelated(X, randomize)
+create_equicorrelated(X, intercept, randomize)
 }
 \description{
 Create equicorrelated fixed-X knockoffs.

--- a/R/knockoff/man/create_sdp.Rd
+++ b/R/knockoff/man/create_sdp.Rd
@@ -4,7 +4,7 @@
 \alias{create_sdp}
 \title{Create SDP fixed-X knockoffs.}
 \usage{
-create_sdp(X, randomize)
+create_sdp(X, intercept, randomize)
 }
 \description{
 Create SDP fixed-X knockoffs.

--- a/R/knockoff/man/decompose.Rd
+++ b/R/knockoff/man/decompose.Rd
@@ -4,7 +4,7 @@
 \alias{decompose}
 \title{Compute the SVD of X and construct an orthogonal matrix U_perp such that U_perp * U = 0.}
 \usage{
-decompose(X, randomize)
+decompose(X, intercept, randomize)
 }
 \description{
 Compute the SVD of X and construct an orthogonal matrix U_perp such that U_perp * U = 0.

--- a/R/knockoff/man/knockoff.filter.Rd
+++ b/R/knockoff/man/knockoff.filter.Rd
@@ -107,5 +107,4 @@ Candes et al., Panning for Gold: Model-free Knockoffs for High-dimensional Contr
   Barber and Candes,
   Controlling the false discovery rate via knockoffs. 
   Ann. Statist. 43 (2015), no. 5, 2055--2085.
-  \doi{10.1214/15-AOS1337}
 }


### PR DESCRIPTION
# Description

In the current implementation, the glmnet-based feature statistics that are compatible with fixed-X knockoffs (e.g. `stat.glmnet_lambdasmax`) implicitly add the intercept to the regression through the default parameter `intercept=T` in `glmnet`. For the fixed-X knockoffs to be valid, the knockoff matrix Xk should also satisfy $X^T 1 = \tilde X^T 1$, where $1$ is the vector of all ones (intercept vector), in addition to the standard conditions. However, the current `create.fixed` function cannot guarantee this extra requirement. As a result, the signs of null $W_j$ might not be Rademacher (conditional on the knockoff statistics), causing potential FDR inflation.

**This pull request adds a new feature.** It added a parameter `intercept` to the function `create.fixed` to generate a valid fixed-X knockoff matrix that satisfies the “augmented” sufficiency principle when an intercept is included in the glmnet-based feature statistics.

If `intercept=TRUE`, the returned `X` will be centered and normalized, `Xk` will be a valid knockoff matrix with `colMeans(Xk) = 0` (so that X^T 1 = Xk^T 1), and `y` will be centered. In other words, all quantities are transformed to be orthogonal to $1$. If `intercept=FALSE` (default), the function `create.fixed` will output the same Xk as in the current implementation.

# Tests

Two more tests are added to `test_create.R` to test that `create.fixed(X, intercept=T)` produces the desired knockoff matrix.